### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@ $(() => {
         { from: 'm', to: 'cm', convertFunc: fromMeterToCentimeter },
 
         // You can specify inline conversions
-        { from: 'cm', to: 'm', convertFunc: value => value / 100 },
+        { from: 'cm', to: 'm', convertFunc: value => value / 100 }, 
+        { from: 'bar', to: 'torr', convertFunc: value => value / 750 },
     ];
     
     function fromMeterToCentimeter(value) {


### PR DESCRIPTION
Das Torr (Einheitenzeichen: Torr) und die Millimeter-Quecksilbersäule (Einheitenzeichen: mmHg, mitunter: mm Hg) sind identische Maßeinheiten des Druckes.[1][2] Die Einheit Millimeter-Quecksilbersäule, teilweise geschrieben Millimeter Quecksilbersäule, wird auch kurz Torr genannt